### PR TITLE
replace getDirection with getCurrentDirection

### DIFF
--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -823,7 +823,7 @@ class CallSession {
             final oldSender = transceiver.sender;
             await oldSender.replaceTrack(newTrack);
             await transceiver.setDirection(
-              await transceiver.getDirection() ==
+              await transceiver.getCurrentDirection() ==
                       TransceiverDirection.Inactive // upgrade, send now
                   ? TransceiverDirection.SendOnly
                   : TransceiverDirection.SendRecv,


### PR DESCRIPTION
`getDirection` isn't implemented on linux in flutter webrtc, but `getCurrentDirection` is ¯\_(ツ)_/¯